### PR TITLE
Define unicode in Python 3 for line 42

### DIFF
--- a/holodeck/util.py
+++ b/holodeck/util.py
@@ -2,6 +2,11 @@
 import math
 import os
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 def get_holodeck_path():
     """Gets the path of the holodeck environment


### PR DESCRIPTION
__unicode__ was removed in Python 3 because all __str__ are Unicode.