### PR TITLE
Use 'FULL BLOCK' (U+2588) for progress

### DIFF
--- a/holodeck/packagemanager.py
+++ b/holodeck/packagemanager.py
@@ -154,7 +154,7 @@ def _download_binary(binary_location, worlds_path, block_size=1000000):
             percent_done = 100 * amount_written / length
             int_percent = int(percent_done)
             num_blocks = int_percent // percent_per_block
-            blocks = chr(0x2589) * num_blocks
+            blocks = chr(0x2588) * num_blocks
             spaces = " " * (max_width - num_blocks)
             try:
                 sys.stdout.write("\r|" + blocks + spaces + "| %d%%" % int_percent)


### PR DESCRIPTION
Another earth shattering change...

The old character 'LEFT SEVEN EIGHTHS BLOCK' (0x2589) didn't display correctly in cmd.exe or powershell on Windows 10. 'FULL BLOCK' plays nicely (and is what pip uses for the same purpose)

![image](https://user-images.githubusercontent.com/7662768/48102822-107ca080-e1ea-11e8-83fb-077ea85251b9.png)

