### PR TITLE
HolodeckEnvironment: implement context manager APIs

### DIFF
--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -406,6 +406,14 @@ class HolodeckEnvironment(object):
             self._world_process.wait(5)
         self._client.unlink()
 
+    # Context manager APIs, allows `with` statement to be used
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # TODO: Surpress exceptions?
+        self.__on_exit__()
+
     def _get_single_state(self):
         reward = None
         terminal = None


### PR DESCRIPTION
This allows the `with` statement to be used on a HolodeckEnvironment object, eg
```python
with holodeck.make("world") as env:
    env.tick()

# env is cleaned up
```
Implements #125 

I don't know if we need to add docstrings to these - let me know.