### PR TITLE
Add RenderViewport command, option to not show Viewport

### DIFF
--- a/holodeck/command.py
+++ b/holodeck/command.py
@@ -269,3 +269,12 @@ class TeleportCameraCommand(Command):
         rotation: A three dimensional array representing rotation in x,y,z
         """
         self.add_number_parameters(rotation)
+
+class RenderViewportCommand(Command):
+    def __init__(self, render_viewport):
+        """
+        :param render_viewport: Boolean if the viewport should be rendered or not
+        """
+        Command.__init__(self)
+        self.set_command_type("RenderViewport")
+        self.add_number_parameters(int(bool(render_viewport)))

--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -73,7 +73,7 @@ class HolodeckEnvironment(object):
 
     def __init__(self, agent_definitions, binary_path=None, task_key=None, window_height=512, window_width=512,
                  camera_height=256, camera_width=256, start_world=True, uuid="", gl_version=4, verbose=False,
-                 pre_start_steps=2):
+                 pre_start_steps=2, show_viewport=True):
         """Constructor for HolodeckEnvironment.
         Positional arguments:
         agent_definitions -- A list of AgentDefinition objects for which agents to expect in the environment
@@ -85,6 +85,7 @@ class HolodeckEnvironment(object):
         start_world -- Whether to load a binary or not (default True)
         uuid -- A unique identifier, used when running multiple instances of holodeck (default "")
         gl_version -- The version of OpenGL to use for Linux (default 4)
+        show_viewport -- If the viewport should be shown (Linux only)
         """
         self._window_height = window_height
         self._window_width = window_width
@@ -98,7 +99,7 @@ class HolodeckEnvironment(object):
 
         if start_world:
             if os.name == "posix":
-                self.__linux_start_process__(binary_path, task_key, gl_version, verbose=verbose)
+                self.__linux_start_process__(binary_path, task_key, gl_version, verbose=verbose, show_viewport=show_viewport)
             elif os.name == "nt":
                 self.__windows_start_process__(binary_path, task_key, verbose=verbose)
             else:
@@ -332,6 +333,15 @@ class HolodeckEnvironment(object):
         command_to_send = TeleportCameraCommand(location, rotation)
         self._commands.add_command(command_to_send)
 
+    def should_render_viewport(self, render_viewport):
+        """Controls whether the viewport is rendered or not
+        Args:
+            render_viewport (boolean): If the viewport should be rendered
+        """
+        self._should_write_to_command_buffer = True
+        command_to_send = RenderViewportCommand(render_viewport)
+        self._commands.add_command(command_to_send)
+
     def set_weather(self, weather_type):
         """Queue up a set weather command. It will be applied when `tick` or `step` is called next.
         By the next tick, the lighting, skysphere, fog, and relevant particle systems will be updated and/or spawned
@@ -366,17 +376,24 @@ class HolodeckEnvironment(object):
         else:
             self.agents[agent_name].set_control_scheme(control_scheme)
 
-    def __linux_start_process__(self, binary_path, task_key, gl_version, verbose):
+    def __linux_start_process__(self, binary_path, task_key, gl_version, verbose, show_viewport=True):
         import posix_ipc
         out_stream = sys.stdout if verbose else open(os.devnull, 'w')
         loading_semaphore = posix_ipc.Semaphore('/HOLODECK_LOADING_SEM' + self._uuid, os.O_CREAT | os.O_EXCL,
                                                 initial_value=0)
+        # Copy the environment variables to remove the DISPLAY variable if we shouldn't show the viewport
+        # see https://answers.unrealengine.com/questions/815764/in-the-release-notes-it-says-the-engine-can-now-cr.html?sort=oldest
+        environment = dict(copy(os.environ))
+        if (show_viewport):
+            del environment['DISPLAY']
+
         self._world_process = subprocess.Popen([binary_path, task_key, '-HolodeckOn', '-opengl' + str(gl_version),
                                                 '-LOG=HolodeckLog.txt', '-ResX=' + str(self._window_width),
                                                 '-ResY=' + str(self._window_height),'-CamResX=' + str(self._camera_width),
                                                 '-CamResY=' + str(self._camera_height), '--HolodeckUUID=' + self._uuid],
                                                stdout=out_stream,
-                                               stderr=out_stream)
+                                               stderr=out_stream,
+                                               env=environment)
 
         atexit.register(self.__on_exit__)
 

--- a/holodeck/holodeck.py
+++ b/holodeck/holodeck.py
@@ -19,7 +19,7 @@ class GL_VERSION(object):
     OPENGL3 = 3
 
 
-def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=None, verbose=False):
+def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=None, verbose=False, show_viewport=True):
     """Creates a holodeck environment using the supplied world name.
 
     Args:
@@ -29,7 +29,7 @@ def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=Non
         window_res ((int, int), optional): The resolution to load the game window at. Defaults to (512, 512).
         cam_res ((int, int), optional): The resolution to load the pixel camera sensors at. Defaults to (256, 256).
         verbose (bool): Whether to run in verbose mode. Defaults to False.
-
+        show_viewport (bool): If the viewport window should be shown on-screen (Linux only). Defaults to True
     Returns:
         HolodeckEnvironment: A holodeck environment instantiated with all the settings necessary for the specified
             world, and other supplied arguments.
@@ -43,10 +43,12 @@ def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=Non
     param_dict["uuid"] = str(uuid.uuid4())
     param_dict["gl_version"] = gl_version
     param_dict["verbose"] = verbose
+    param_dict["show_viewport"] = show_viewport
 
     if window_res is not None:
         param_dict["window_width"] = window_res[0]
         param_dict["window_height"] = window_res[1]
+
     if cam_res is not None:
         param_dict["camera_width"] = cam_res[0]
         param_dict["camera_height"] = cam_res[1]


### PR DESCRIPTION
Adds (1) a command to toggle viewport rendering and (2) an option to run headless on Linux. Part of #135

The command to toggle viewport rendering is exposed to the user with the should_render_viewport method on HolodeckEnvironment. Depends on
BYU-PCCL/holodeck-engine@8684316966bea433ed58e68238ed0a2e71fb841f