### PR TITLE
Add Copy State Option

### DIFF
--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -6,7 +6,7 @@ import atexit
 import os
 import subprocess
 import sys
-from copy import copy, deepcopy
+from copy import copy
 
 from holodeck.command import *
 from holodeck.exceptions import HolodeckException
@@ -520,12 +520,23 @@ class HolodeckEnvironment(object):
             elif sensor == Sensors.TERMINAL:
                 terminal = self._sensor_map[self._agent.name][sensor][0]
 
-        state = deepcopy(self._sensor_map[self._agent.name]) if self._copy_state \
+        state = self._create_copy(self._sensor_map[self._agent.name]) if self._copy_state \
             else copy(self._sensor_map[self._agent.name])
         return state, reward, terminal, None
 
     def _get_full_state(self):
-        return deepcopy(self._sensor_map) if self._copy_state else copy(self._sensor_map)
+        return self._create_copy(self._sensor_map) if self._copy_state else copy(self._sensor_map)
+
+    def _create_copy(self, obj):
+        if type(obj) is dict:  # Deep copy dictionary
+            cp = dict()
+            for k, v in obj.items():
+                if type(v) is dict:
+                    cp[k] = self._create_copy(v)
+                else:
+                    cp[k] = np.copy(v)
+            return cp
+        return None  # Not implemented for other types
 
     def _handle_command_buffer(self):
         """Checks if we should write to the command buffer, writes all of the queued commands to the buffer, and then

--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -528,10 +528,10 @@ class HolodeckEnvironment(object):
         return self._create_copy(self._sensor_map) if self._copy_state else copy(self._sensor_map)
 
     def _create_copy(self, obj):
-        if type(obj) is dict:  # Deep copy dictionary
+        if isinstance(dict):  # Deep copy dictionary
             cp = dict()
             for k, v in obj.items():
-                if type(v) is dict:
+                if isinstance(dict):
                     cp[k] = self._create_copy(v)
                 else:
                     cp[k] = np.copy(v)

--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -520,11 +520,12 @@ class HolodeckEnvironment(object):
             elif sensor == Sensors.TERMINAL:
                 terminal = self._sensor_map[self._agent.name][sensor][0]
 
-        state = deepcopy(self._sensor_map[self._agent.name]) if self._copy_state else self._sensor_map[self._agent.name]
+        state = deepcopy(self._sensor_map[self._agent.name]) if self._copy_state \
+            else copy(self._sensor_map[self._agent.name])
         return state, reward, terminal, None
 
     def _get_full_state(self):
-        return deepcopy(self._sensor_map) if self._copy_state else self._sensor_map
+        return deepcopy(self._sensor_map) if self._copy_state else copy(self._sensor_map)
 
     def _handle_command_buffer(self):
         """Checks if we should write to the command buffer, writes all of the queued commands to the buffer, and then

--- a/holodeck/holodeck.py
+++ b/holodeck/holodeck.py
@@ -19,7 +19,8 @@ class GL_VERSION(object):
     OPENGL3 = 3
 
 
-def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=None, verbose=False, show_viewport=True):
+def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=None, verbose=False, show_viewport=True,
+         copy_state=True):
     """Creates a holodeck environment using the supplied world name.
 
     Args:
@@ -30,6 +31,7 @@ def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=Non
         cam_res ((int, int), optional): The resolution to load the pixel camera sensors at. Defaults to (256, 256).
         verbose (bool): Whether to run in verbose mode. Defaults to False.
         show_viewport (bool): If the viewport window should be shown on-screen (Linux only). Defaults to True
+        copy_state (bool): If the state should be copied or passed as a reference when returned. Defaults to True
     Returns:
         HolodeckEnvironment: A holodeck environment instantiated with all the settings necessary for the specified
             world, and other supplied arguments.
@@ -44,6 +46,7 @@ def make(world_name, gl_version=GL_VERSION.OPENGL4, window_res=None, cam_res=Non
     param_dict["gl_version"] = gl_version
     param_dict["verbose"] = verbose
     param_dict["show_viewport"] = show_viewport
+    param_dict["copy_state"] = copy_state
 
     if window_res is not None:
         param_dict["window_width"] = window_res[0]


### PR DESCRIPTION
Previously, when returning the state after a step, env used copy to return the sensor map. This created a shallow copy instead of a deep copy.