### PR TITLE
Assert `reset` called before `tick()` and `step` (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Here is a basic walkthrough of an example that runs a Holodeck world:
 import holodeck
 import numpy as np
 env = holodeck.make("UrbanCity")    # Load the environment. This environment contains a UAV in a city.
+env.reset()                         # You must call `.reset()` on a newly created environment before ticking/stepping it
 command = np.array([0, 0, 0, 100])  # The UAV takes 3 torques and a thrust as a command.
 for i in range(30):
     state, reward, terminal, info = env.step(command)  # Pass the command to the environment with step.

--- a/holodeck/environments.py
+++ b/holodeck/environments.py
@@ -130,6 +130,9 @@ class HolodeckEnvironment(object):
         self._should_write_to_command_buffer = False
 
         self._client.acquire()
+        
+        # Flag indicates if the user has called .reset() before .tick() and .step()
+        self._initial_reset = False
 
     @property
     def action_space(self):
@@ -171,6 +174,7 @@ class HolodeckEnvironment(object):
             tuple or dict: For single agent environment, returns the same as `step`.
                 For multi-agent environment, returns the same as `tick`.
         """
+        self._initial_reset = True
         self._reset_ptr[0] = True
         self._commands.clear()
 
@@ -193,6 +197,9 @@ class HolodeckEnvironment(object):
             Terminal is the bool terminal signal returned by the environment.
             Info is any additional info, depending on the world. Defaults to None.
         """
+        if not self._initial_reset:
+            raise HolodeckException("You must call .reset() before .step()")
+
         self._agent.act(action)
 
         self._handle_command_buffer()
@@ -235,6 +242,9 @@ class HolodeckEnvironment(object):
             from :obj:`holodeck.sensors.Sensors` enum to np.ndarray, containing the sensors information
             for each sensor. The sensors always include the reward and terminal sensors.
         """
+        if not self._initial_reset:
+            raise HolodeckException("You must call .reset() before .tick()")
+
         self._handle_command_buffer()
         self._client.release()
         self._client.acquire()

--- a/holodeck/sensors.py
+++ b/holodeck/sensors.py
@@ -1,6 +1,6 @@
 """Definition of all of the sensor information"""
 import numpy as np
-
+from holodeck.exceptions import HolodeckException
 
 class Sensors:
     """Class information of sensor data with mappings from names to corresponding numbers
@@ -131,7 +131,13 @@ class Sensors:
         Returns:
             int: The index value for the sensor.
         """
-        return Sensors._reverse_name_dict[sensor_name] if sensor_name in Sensors._reverse_name_dict else None
+        if sensor_name in Sensors._reverse_name_dict:
+            return Sensors._reverse_name_dict[sensor_name]
+        else:
+            raise HolodeckException(
+                "Unable to find sensor ID for '{}', are your binaries out of date?".format(sensor_name)
+                )
+
 
     @staticmethod
     def set_primary_cam_size(height, width):


### PR DESCRIPTION
1. **#156 Require the user to call `.reset()` before `.tick()`.**
    More closely aligns with the OpenAI gym interface.
2. **Fail more obviously when a sensor name isn't found**
    Previously this helper would return None and it would fail with a weird error somewhere else.
    This change should probably be added to the other helper functions in this file as well. #157 would render this a moot point