### PR TITLE
Package Manager 2.0

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,174 @@
+# Holodeck Packages and Configuration
+How packages are installed, managed, and interpreted in holodeck.
+
+## Package Installation
+
+Packages are located on an S3 bucket, due to the size of the files and the 
+bandwidth required to distribute them. 
+
+### Retrieving Package List
+A version of holodeck has a certain set of packages that are associated with it. 
+Each package can have multiple versions, and a version of holodeck can be 
+compatible with multiple versions of a package. A package can also be added
+after shipping a version of holodeck, so the client fetches a list of available
+packages from the backend.
+
+The client will post a GET to the following endpoint:
+`%BACKEND%/packages/%HOLODECK_VERSION%/available`, or
+`https://s3.amazonaws.com/holodeckworlds/packages/0.2.0/available` for example.
+
+The server will return a JSON file with the following format:
+
+```json
+{
+    "packages": {
+        "%WORLD_NAME%" : ["%VERSION1", "%VERSION_2%"]
+    }
+}
+```
+
+for example
+
+```json
+{
+    "packages": {
+        "DefaultWorlds" : ["0.1.0", "0.1.1"],
+        "MoveBox" : ["0.0.1"]
+    }
+}
+```
+
+The client will use this information to craft the download URL.
+
+### Download URL
+
+This is the format of a download URL:
+
+`%BACKEND%/packages/%HOLODECK_VERSION%/%PACKAGE_NAME%/%PLATFORM%/%PACKAGE_VERSION%.zip`
+
+for example
+
+`%BACKEND%/packages/0.1.0/DefaultWorlds/Linux/1.0.2.zip`
+
+### Installation Location
+
+Packages are saved in a holodeck version dependent subfolder. So for holodeck 
+version `0.2.0`, all worlds will be saved in
+`%HOLODECKPATH%/%HOLODECK_VERSION%/worlds`
+
+This will prevent holodeck from loading binaries from the wrong version, and 
+will also allow multiple versions of holodeck to be installed at once.
+
+A package may have multiple versions, but only one version of a package must 
+be installed at a given time. This is because world names are assumed to be
+unique between all installed packages currently, so having two versions of 
+the package would cause issues.
+
+## Package Config File Format
+
+Each package has a `config.json` file located in the root of the archive. This 
+configuration file defines the worlds that are in that package, and defines the
+ agents in the world if it doesn't use dynamic spawning.
+
+### `config.json`
+```json
+{  
+    "name":"{package_name}",
+    "platform":"{Linux | Windows}",
+    "version":"{package_version}",
+    "path" : "{path to binary within the archive}",
+    "maps": [  
+        "{map-objects}",
+    ]
+}
+```
+
+### `map` object
+The `map` object defines the maps that are available in a package. 
+
+Here is an example of a complete map object
+
+```json
+{  
+    "name": "{map_name}",
+    "pre_start_steps": 2,
+    "default_scenario": "{name of default scenario - eg Follow}"
+}
+```
+
+## Scenario Config File Format
+
+A map may have several different scenarios associated with it. The filename of 
+a scenario file distributed in a package must be `%WORLD_NAME%-%SCENARIO_NAME%.json`, 
+for example `UrbanCity-Follow.json`. The scenario defines the agents and tasks
+ that should be spawned in the world when an object is created.
+
+Here is the file format for a scenario:
+
+```json
+{
+    "name": "{Scenario Name}",
+    "world": "{Map it is associated with}",
+
+    "agents":[
+        "array of agent objects"
+    ],
+
+    "window_width":  1280,
+    "window_height": 720
+}
+```
+The first agent defined in the `agents` array is the main agent.
+
+All coordinates are right handed.
+### Agent Object
+For use with a scenario file only.
+
+```json
+
+{
+    "agent_name": "uav0",
+    "agent_type": "{agent types}",
+    "sensors": [
+        "array of sensor objects"
+    ],
+    "control_scheme": "{control scheme type}",
+    "location": [1.0, 2.0, 3.0],
+    "rotation": [1.0, 2.0, 3.0]
+}
+```
+
+#### Agent Types
+ - `UavAgent`
+ - `SphereAgent`
+ - `AndroidAgent`
+ - `NavAgent`
+ - `TurtleAgent`
+ - `BoatAgent`
+
+#### Control Schemes
+Depends on the agent type
+
+| Agent Type | Scheme                        |
+|-----------:|-------------------------------|
+| Android    | `android_torques`             |
+| Sphere     | `sphere_discrete`             |
+| Sphere     | `sphere_continuous`           |
+| Nav Agent  | `nav_target_location`         |
+| UAV        | `uav_torques`                 |
+| UAV        | `uav_roll_pitch_yaw_rate_alt` |
+
+### Sensor Object
+All coordinates are right handed. Note that the coordinates are 
+
+```json
+{
+    "sensor_type": "RGBCamera",
+    "location": [1.0, 2.0, 3.0],
+    "rotation": [1.0, 2.0, 3.0],
+    "socket": "socket name or """,
+    "configuration": {
+        "note": "Each sensor has a different configuration. This object is passed in verbatim to the C++ sensor object"
+    }
+}
+```

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -164,6 +164,7 @@ All coordinates are right handed. Note that the coordinates are
 ```json
 {
     "sensor_type": "RGBCamera",
+    "sensor_name": "FrontCamera",
     "location": [1.0, 2.0, 3.0],
     "rotation": [1.0, 2.0, 3.0],
     "socket": "socket name or """,

--- a/holodeck/holodeck.py
+++ b/holodeck/holodeck.py
@@ -7,6 +7,7 @@ from holodeck.environments import HolodeckEnvironment, AgentDefinition
 from holodeck.exceptions import HolodeckException
 from holodeck.packagemanager import _iter_packages
 
+print("Yee haw")
 
 class GL_VERSION(object):
     """OpenGL Version enum.

--- a/holodeck/holodeck.py
+++ b/holodeck/holodeck.py
@@ -7,7 +7,6 @@ from holodeck.environments import HolodeckEnvironment, AgentDefinition
 from holodeck.exceptions import HolodeckException
 from holodeck.packagemanager import _iter_packages
 
-print("Yee haw")
 
 class GL_VERSION(object):
     """OpenGL Version enum.

--- a/holodeck/packagemanager.py
+++ b/holodeck/packagemanager.py
@@ -165,7 +165,7 @@ def install(package_name, version=None):
         return
 
     if version is None:
-        # TODO: More robust verison parsing
+        # TODO: More robust version parsing
         version = max(packages[package_name])
 
     # example: %backend%/packages/0.1.0/DefaultWorlds/Linux/1.0.2.zip

--- a/holodeck/packagemanager.py
+++ b/holodeck/packagemanager.py
@@ -351,7 +351,3 @@ def _download_binary(binary_location, install_location, block_size=1000000):
     with zipfile.ZipFile(tmp_fd, 'r') as zip_file:
         zip_file.extractall(install_location)
     print("Finished.")
-
-
-scene = get_scenario("CyberPunkCity-Follow")
-config = get_package_config_for_scenario(scene)

--- a/holodeck/packagemanager.py
+++ b/holodeck/packagemanager.py
@@ -5,26 +5,48 @@ import shutil
 import sys
 import tempfile
 import urllib.request
+import urllib.error
+import fnmatch
 import zipfile
+import pprint
 from queue import Queue
 from threading import Thread
 
 from holodeck import util
 from holodeck.exceptions import HolodeckException
 
-packages = {
-    "DefaultWorlds": "DefaultWorlds_0.1.0.zip",
-    "MoveBox": "MoveBox_0.0.1.zip"
-}
+backend_url = "https://s3.amazonaws.com/holodeckworlds/"
 
 
-def all_packages():
-    """Returns a list of all downloadable package names
+def _get_from_backend(rel_url):
+    """
+    Gets the resource given at rel_url, assumes it is a text file
+    Args:
+        rel_url (str): url relative to backend_url to fetch
+
+    Returns (str): The resource at rel_url as a string
+    """
+    r = urllib.request.urlopen(backend_url + rel_url)
+    data = r.read()
+    return data.decode('utf-8')
+
+
+def available_packages():
+    """Returns a dictionary of package name to list of versions for all downloadable packages
 
     Returns:
-        (list): List of all the downloadable packages
+        (list): Dictionary of package name : [versions]
     """
-    return list(packages.keys())
+    # Get the index json file from the backend
+    url = "packages/{ver}/available".format(ver=util.get_holodeck_version())
+    try:
+        index = _get_from_backend(url)
+        index = json.loads(index)
+    except urllib.error.URLError as err:
+        print("Unable to communicate with backend ({}), {}".format(url, err.reason), file=sys.stderr)
+        return
+
+    return index["packages"]
 
 
 def installed_packages():
@@ -51,17 +73,27 @@ def package_info(pkg_name):
             print(indent, "Path:", config["path"])
             print(indent, "Worlds:")
             for world in config["maps"]:
-                world_info(world["name"], world_config=world, initial_indent="    ")
+                world_info(world["name"], world_config=world, base_indent=4)
 
 
-def world_info(world_name, world_config=None, initial_indent="", next_indent="  "):
+def _print_agent_info(agents, base_indent=0):
+    print(base_indent*' ', "Agents:")
+    base_indent += 2
+    for agent in agents:
+        print(base_indent*' ', "Name:", agent["agent_name"])
+        print(base_indent*' ', "Type:", agent["agent_type"])
+        print(base_indent*' ', "Sensors:")
+        for sensor in agent["sensors"]:
+            print((base_indent + 2)*' ', sensor)
+
+
+def world_info(world_name, world_config=None, base_indent=0):
     """Gets and prints the information of a world.
 
     Args:
         world_name (str): the name of the world to retrieve information for
         world_config (dict optional): A dictionary containing the world's configuration. Will find the config if None. Defaults to None.
-        initial_indent (str optional): This indent will apply to each output line. Defaults to "".
-        next_indent (str optional): This indent will be applied within each nested line. Defaults to "  ".
+        base_indent (int): How much to indent output
     """
     if world_config is None:
         for config, _ in _iter_packages():
@@ -72,43 +104,79 @@ def world_info(world_name, world_config=None, initial_indent="", next_indent="  
     if world_config is None:
         raise HolodeckException("Couldn't find world " + world_name)
 
-    second_indent = initial_indent + next_indent
-    agent_indent = second_indent + next_indent
-    sensor_indent = agent_indent + next_indent
+    print(base_indent*' ', world_config["name"])
+    base_indent += 4
+    print(base_indent*' ', "Resolution:", world_config["window_width"], "x", world_config["window_height"])
 
-    print(initial_indent, world_config["name"])
-    print(second_indent, "Resolution:", world_config["window_width"], "x", world_config["window_height"])
-    print(second_indent, "Agents:")
-    for agent in world_config["agents"]:
-        print(agent_indent, "Name:", agent["agent_name"])
-        print(agent_indent, "Type:", agent["agent_type"])
-        print(agent_indent, "Sensors:")
-        for sensor in agent["sensors"]:
-            print(sensor_indent, sensor)
+    if "agents" in world_config:
+        _print_agent_info(world_config["agents"], base_indent)
+
+    print(base_indent*' ', "Scenarios:")
+    for scenario, path in _iter_scenarios(world_name):
+        scenario_info(scenario=scenario, base_indent=base_indent + 2)
 
 
-def install(package_name):
+def _find_file_in_worlds_dir(filename):
+    for root, dirnames, filenames in os.walk(util.get_holodeck_path(), "worlds"):
+        for match in fnmatch.filter(filenames, filename):
+            return os.path.join(root, match)
+
+
+def scenario_info(world_name="", scenario_name="", scenario=None, base_indent=0):
+    """Gets and prints information for a particular scenario file
+    Must match this format: world_name-scenario_name.json
+
+    Args:
+        world_name (str): The name of the world
+        scenario_name (str): The name of the scenario
+        scenario: Loaded dictionary config (overrides world_name and scenario_name)
+        base_indent: How much to indent output by
+    """
+    scenario_file = ""
+    if scenario is None:
+        # Find this file in the worlds/ directory
+        filename = '{}-{}.json'.format(world_name, scenario_name)
+        scenario_file = _find_file_in_worlds_dir(filename)
+
+        if scenario_file == "":
+            raise FileNotFoundError("The file {} could not be found".format(filename))
+
+        with open(scenario_file, 'r') as f:
+            scenario = json.load(f)
+
+    print(base_indent*' ', "{}-{}:".format(scenario["world"], scenario["name"]))
+    base_indent += 2
+    if "agents" in scenario:
+        _print_agent_info(scenario["agents"], base_indent)
+
+
+def install(package_name, version=None):
     """Installs a holodeck package.
 
     Args:
         package_name (str): The name of the package to install
     """
     holodeck_path = util.get_holodeck_path()
-    binary_website = "https://s3.amazonaws.com/holodeckworlds/"
 
+    packages = available_packages()
     if package_name not in packages:
-        package_url = package_name
-        split = package_name.split("_")
-        package_name = split[0]
-    else:
-        package_url = packages[package_name]
+        print("Package not found. Available package are:", file=sys.stderr)
+        pprint.pprint(packages, width=10, indent=4, stream=sys.stderr)
+        return
 
-    print("Installing " + package_name + " at " + holodeck_path)
-    install_path = os.path.join(holodeck_path, "worlds")
-    binary_url = binary_website + util.get_os_key() + "_" + package_url
+    if version is None:
+        # TODO: More robust verison parsing
+        version = max(packages[package_name])
+
+    # example: %backend%/packages/0.1.0/DefaultWorlds/Linux/1.0.2.zip
+    binary_url = "{}packages/{}/{}/{}/{}.zip".format(backend_url, util.get_holodeck_version(),
+                                                     package_name, util.get_os_key(), version)
+
+    print("Installing {} ver. {} from {}".format(package_name, version, binary_url))
+
+    install_path = os.path.join(holodeck_path, "worlds", package_name)
+
     _download_binary(binary_url, install_path)
-    if os.name == "posix":
-        _make_binary_excecutable(package_name, install_path)
 
 
 def remove(package_name):
@@ -117,8 +185,6 @@ def remove(package_name):
     Args:
         package_name (str): the name of the package to remove
     """
-    if package_name not in packages:
-        raise HolodeckException("Unknown package name " + package_name)
     for config, path in _iter_packages():
         if config["name"] == package_name:
             shutil.rmtree(path)
@@ -147,7 +213,45 @@ def _iter_packages():
                     yield config, full_path
 
 
-def _download_binary(binary_location, worlds_path, block_size=1000000):
+def _iter_scenarios(world_name):
+    """Iterates over the scenarios associated with world_name.
+
+    Note that world_name needs to be unique among all packages
+
+    Args:
+        world_name (str): name of the world
+
+    Returns: config_dict, path_to_config
+    """
+    package_path = os.path.join(util.get_holodeck_path(), "worlds", world_name)
+
+    # Find a scenario for this world
+    a_scenario = _find_file_in_worlds_dir("{}-*".format(world_name))
+
+    if a_scenario is None:
+        return
+
+    # Find the parent path of that file
+    world_path = os.path.abspath(os.path.join(a_scenario, os.pardir))
+
+    if not os.path.exists(world_path):
+        os.makedirs(world_path)
+    for file_name in os.listdir(world_path):
+        if file_name == "config.json":
+            continue
+        if not file_name.endswith(".json"):
+            continue
+        if not fnmatch.fnmatch(file_name, "{}-*.json".format(world_name)):
+            continue
+
+
+        full_path = os.path.join(world_path, file_name)
+        with open(full_path, 'r') as f:
+            config = json.load(f)
+            yield config, full_path
+
+
+def _download_binary(binary_location, install_location, block_size=1000000):
     def file_writer_worker(tmp_fd, length, q):
         max_width = 20
         percent_per_block = 100 // max_width
@@ -163,7 +267,7 @@ def _download_binary(binary_location, worlds_path, block_size=1000000):
             try:
                 sys.stdout.write("\r|" + blocks + spaces + "| %d%%" % int_percent)
             except UnicodeEncodeError:
-                print("\r"+str(int_percent)+"%", end="")
+                print("\r" + str(int_percent) + "%", end="")
 
             sys.stdout.flush()
 
@@ -182,15 +286,11 @@ def _download_binary(binary_location, worlds_path, block_size=1000000):
         print()
 
     # Unzip the binary
+    # Note the contents of the ZIP file get extracted straight into the install directory, so the zip's structure should
+    # look like file.zip/config.json not file.zip/file/config.json
     print("Unpacking worlds...")
     with zipfile.ZipFile(tmp_fd, 'r') as zip_file:
-        zip_file.extractall(worlds_path)
+        zip_file.extractall(install_location)
     print("Finished.")
 
 
-def _make_binary_excecutable(package_name, worlds_path):
-    complete_name = "Linux" + package_name
-    for path, _, _ in os.walk(os.path.join(worlds_path, complete_name)):
-        os.chmod(path, 0o777)
-    binary_path = os.path.join(worlds_path, complete_name + "/LinuxNoEditor/Holodeck/Binaries/Linux/Holodeck")
-    os.chmod(binary_path, 0o755)

--- a/holodeck/util.py
+++ b/holodeck/util.py
@@ -8,6 +8,9 @@ except NameError:
     unicode = str  # Python 3
 
 
+def get_holodeck_version():
+    return "0.2.0"
+
 def get_holodeck_path():
     """Gets the path of the holodeck environment
 
@@ -17,11 +20,12 @@ def get_holodeck_path():
     if "HOLODECKPATH" in os.environ and os.environ["HOLODECKPATH"] != "":
         return os.environ["HOLODECKPATH"]
     if os.name == "posix":
-        return os.path.expanduser("~/.local/share/holodeck")
+        path = os.path.expanduser("~/.local/share/holodeck")
     elif os.name == "nt":
-        return os.path.expanduser("~\\AppData\\Local\\holodeck")
+        path = os.path.expanduser("~\\AppData\\Local\\holodeck")
     else:
         raise NotImplementedError("holodeck is only supported for Linux and Windows")
+    return os.path.join(path, get_holodeck_version())
 
 
 def convert_unicode(value):


### PR DESCRIPTION

Don't hardcode packages (#188)

 - packagemanager now checks a server to see which packages are ready.
    - This will allow us to update packages and add them after doing a release
 - Packages are now saved in a holodeck version dependent subfolder
    - This will prevent holodeck from loading binaries from the wrong version
    - Will also allow multiple versions of holodeck to be installed
 - Packages can now be versioned
    - The server will return a list of versions for a specific package
    - The client will by default pick the highest version
- Changed expected backend URL structure
    - ex. `%backend%/packages/0.1.0/DefaultWorlds/Linux/1.0.2.zip`
- Zip files must not have a single folder in the root that is the name of the archive
    -`file.zip/config.json` not `file.zip/file/config.json`
- Add utility function to get holodeck version