### PR TITLE
Remove `set_state` and `teleport` from `HolodeckEnvironment`

### DIFF
--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -325,38 +325,6 @@ class HolodeckEnvironment:
 
         return self._default_state_fn()
 
-    def teleport(self, agent_name, location=None, rotation=None):
-        """Teleports the target agent to any given location, and applies a specific rotation.
-
-        Args:
-            agent_name (:obj:`str`): The name of the agent to teleport.
-            location (:obj:`np.ndarray` or :obj:`list`): XYZ coordinates (in meters) for the agent
-                to be teleported to.
-
-                If no location is given, it isn't teleported, but may still be rotated. Defaults to
-                None.
-            rotation (:obj:`np.ndarray` or :obj:`list`): A new rotation target for the agent.
-                If no rotation is given, it isn't rotated, but may still be teleported. Defaults to
-                None.
-        """
-        self.agents[agent_name].teleport(location, rotation)
-
-    def set_state(self, agent_name, location, rotation, velocity, angular_velocity):
-        """Sets a new state for any agent given a location, rotation and linear and angular
-        velocity. Will sweep and be blocked by objects in it's way however
-
-        Args:
-            agent_name (:obj:`str`): The name of the agent to teleport.
-            location (:obj:`np.ndarray` or :obj:`list`): New ``[x, y, z]`` coordinates for agent
-                (see :ref:`coordinate-system`).
-            rotation (:obj:`np.ndarray` or :obj:`list`): ``[roll, pitch, yaw`` rotation for the agent
-                (see :ref:`rotations`).
-            velocity (:obj:`np.ndarray` or :obj:`list`): New velocity ``[x, y, z]`` for the agent.
-            angular velocity (:obj:`np.ndarray` or :obj:`list`): A new angular velocity for the
-                agent in **degrees**
-        """
-        self.agents[agent_name].set_state(location, rotation, velocity, angular_velocity)
-
     def _enqueue_command(self, command_to_send):
         self._command_center.enqueue_command(command_to_send)
 
@@ -557,7 +525,7 @@ class HolodeckEnvironment:
 
         self.send_world_command("SetWeather", string_params=[weather_type])
 
-    def teleport_camera(self, location, rotation):
+    def move_viewport(self, location, rotation):
         """Teleport the camera to the given location
 
         By the next tick, the camera's location and rotation will be updated

--- a/tests/sensors/test_location_sensor.py
+++ b/tests/sensors/test_location_sensor.py
@@ -39,7 +39,7 @@ def test_location_sensor_after_teleport():
             env.tick()
 
         loc = [507, 301, 1620]
-        env.teleport("sphere0", loc)
+        env.agents['sphere0'].teleport(loc, [0,0,0])
 
         state = env.tick()
         sensed_loc = state["LocationSensor"]

--- a/tests/sensors/test_orientation_sensor.py
+++ b/tests/sensors/test_orientation_sensor.py
@@ -40,7 +40,7 @@ def test_orientation_sensor_after_teleport():
 
         loc = [123, 3740, 1030]
         rot_deg = np.array([0, 90, 0])
-        env.teleport("sphere0", loc, rot_deg)
+        env.agents["sphere0"].teleport(loc, rot_deg)
         state = env.tick()
         sensed_orientation = state["OrientationSensor"]
 

--- a/tests/sensors/test_rotation_sensor.py
+++ b/tests/sensors/test_rotation_sensor.py
@@ -41,7 +41,7 @@ def test_rotation_sensor_after_teleport():
 
         loc = [123, 3740, 1030]
         rot_deg = np.array([0, 90, 0])
-        env.teleport("sphere0", loc, rot_deg)
+        env.agents['sphere0'].teleport(loc, rot_deg)
         rotation = env.tick()["RotationSensor"]
 
         assert almost_equal(rot_deg, rotation), "The agent rotated in an unexpected manner!"

--- a/tests/sensors/test_viewport_capture.py
+++ b/tests/sensors/test_viewport_capture.py
@@ -74,7 +74,7 @@ def test_viewport_capture_after_teleport(env_1024, request):
 
     # Other tests muck with this. Set it to true just in case
     env_1024.should_render_viewport(True)
-    env_1024.teleport_camera([.9, -1.75, .5], [0, 0, 0])
+    env_1024.move_viewport([.9, -1.75, .5], [0, 0, 0])
 
     for _ in range(5):
         env_1024.tick()
@@ -106,7 +106,7 @@ def validate_rendering_viewport_disabled(env_1024, between_tests_callback):
 
     between_tests_callback(env_1024)
 
-    env_1024.teleport_camera([781, 643, 4376], [381, 403, 3839])
+    env_1024.move_viewport([781, 643, 4376], [381, 403, 3839])
 
     start = time.perf_counter()
     for _ in range(10):


### PR DESCRIPTION
Also rename `teleport_camera` to `move_viewport` to be less vague.

#311 