### PR TITLE
Fix set_ticks_per_capture (#197)

### DIFF
--- a/docs/changelog/changelog.rst
+++ b/docs/changelog/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+.. Changelog Style Guide
+  - Each release should have a New Features / Changes / Bug Fixes section.
+  - Keep the first sentence of each point short and descriptive
+  - The passive voice should be avoided
+  - Try to make the first word a verb in past tense. Bug fixes should use 
+    "Fixed"
+  - Add a link to the issue describing the change or the pull request that 
+    merged it at the end in parentheses
+
 Holodeck 0.3.0
 --------------
 *Release Date TBD*
@@ -20,7 +29,8 @@ New Features
 - Packages can be installed directly from a URL
   (see :class:`~holodeck.packagemanager.install`)
   (`#129 <https://github.com/BYU-PCCL/holodeck/issues/129>`_)
-- Agent sensors can now be rotated at run time
+- Agent sensors can now be rotated at run time with
+  :meth:`~holodeck.sensors.HolodeckSensor.rotate`.
   (`#305 <https://github.com/BYU-PCCL/holodeck/issues/305>`_)
 - The config files can now specify whether an agent should be spawned
   (`#303 <https://github.com/BYU-PCCL/holodeck/pull/303>`_)
@@ -57,6 +67,13 @@ Changes
   :class:`~holodeck.agents.HolodeckAgent` class. See the linked issue for 
   migration suggestions 👉
   (`#311 <https://github.com/BYU-PCCL/holodeck/issues/311>`_)
+- Removed the ``get/set_ticks_per_capture`` methods from the 
+  :class:`~holodeck.agents.HolodeckAgent` and 
+  :class:`~holodeck.environments.HolodeckEnvironment` classes, moved
+  :meth:`~holodeck.sensors.RGBCamera.set_ticks_per_capture` method to the
+  :class:`~holodeck.sensors.RGBCamera` class. 
+  (`#197 <https://github.com/BYU-PCCL/holodeck/issues/197>`_)
+
 
 Bug Fixes
 ~~~~~~~~~
@@ -76,7 +93,10 @@ Bug Fixes
 - Fixed agent spawn rotations being in the incorrect order. Fixed the
   documentation that specified the incorrect order as well (:ref:`rotations`)
   (`#309 <https://github.com/BYU-PCCL/holodeck/issues/309>`_)
-  
+- Fixed being unable to set the ticks per capture of a camera if it was not
+  named ``RGBCamera``.
+  (`#197 <https://github.com/BYU-PCCL/holodeck/issues/197>`_)
+
 
 Holodeck 0.2.2
 --------------

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -67,7 +67,7 @@ The number of ticks per capture can be adjusted to give a lower average frame
 time.
 
 See the 
-:meth:`~holodeck.environments.HolodeckEnvironment.set_ticks_per_capture` method.
+:meth:`~holodeck.sensors.RGBCamera.set_ticks_per_capture` method.
 
 Disable Viewport Rendering
 --------------------------

--- a/src/holodeck/agents.py
+++ b/src/holodeck/agents.py
@@ -89,10 +89,6 @@ class HolodeckAgent:
         self._current_control_scheme = 0
         self.set_control_scheme(0)
 
-        self._ticks_per_capture = 1
-        self.set_ticks_per_capture(1)
-        self.get_ticks_per_capture()
-
     def act(self, action):
         """Sets the command for the agent. Action depends on the agent type and current control
         scheme.
@@ -116,22 +112,6 @@ class HolodeckAgent:
         """
         self._current_control_scheme = index % self._num_control_schemes
         self._control_scheme_buffer[0] = self._current_control_scheme
-
-    def set_ticks_per_capture(self, ticks_per_capture):
-        """Sets the ticks per capture for the agent's rgb camera.
-
-        Args:
-            ticks_per_capture (:obj:`int`): The ticks per capture for the agent's rgb camera
-        """
-        self._ticks_per_capture = ticks_per_capture
-
-    def get_ticks_per_capture(self):
-        """Gets the ticks per capture for the agent's rgb camera.
-
-        Returns:
-            :obj:`int`: The ticks per capture for the agent's rgb camera
-        """
-        return self._ticks_per_capture
 
     def teleport(self, location=None, rotation=None):
         """Teleports the agent to a specific location, with a specific rotation.

--- a/src/holodeck/command.py
+++ b/src/holodeck/command.py
@@ -387,13 +387,15 @@ class RGBCameraRateCommand(Command):
 
     Args:
         agent_name (:obj:`str`): name of the agent to modify
+        sensor_name (:obj:`str`): name of the sensor to modify
         ticks_per_capture (:obj:`int`): number of ticks between captures
 
     """
-    def __init__(self, agent_name, ticks_per_capture):
+    def __init__(self, agent_name, sensor_name, ticks_per_capture):
         Command.__init__(self)
         self._command_type = "RGBCameraRate"
         self.add_string_parameters(agent_name)
+        self.add_string_parameters(sensor_name)
         self.add_number_parameters(ticks_per_capture)
 
 

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -367,48 +367,6 @@ class HolodeckEnvironment:
         if is_main_agent:
             self._agent = self.agents[agent_def.name]
 
-    def set_ticks_per_capture(self, agent_name, ticks_per_capture):
-        """Queues a rgb camera rate command. It will be applied when :meth:`tick` or :meth:`step` is
-        called next.
-
-        The specified agent's rgb camera will capture images every specified number of ticks.
-
-        The sensor's image will remain unchanged between captures.
-
-        This method must be called after every call to env.reset.
-
-        Args:
-            agent_name (:obj:`str`): The name of the agent whose rgb camera should be modified.
-            ticks_per_capture (:obj:`int`): The amount of ticks to wait between camera captures.
-        """
-        if not isinstance(ticks_per_capture, int) or ticks_per_capture < 1:
-            print("Ticks per capture value " + str(ticks_per_capture) + " invalid")
-        elif agent_name not in self.agents:
-            print("No such agent %s" % agent_name)
-        else:
-            self.agents[agent_name].set_ticks_per_capture(ticks_per_capture)
-            command_to_send = RGBCameraRateCommand(agent_name, ticks_per_capture)
-            self._enqueue_command(command_to_send)
-
-    def rotate_sensor(self, agent_name, sensor_name, rotation):
-        """Queues a rotate sensor command. It will be applied when :meth:`tick` or :meth:`step` is
-        called next.
-
-        The specified sensor on the specified agent will be immediately set to the given rotation
-
-        Args:
-            agent_name (:obj:`str`): Name of agent to modify
-            sensor_name (:obj:`str`): Name of the sensor to rotate
-            rotation (:obj:`list` of :obj:`float`): ``[roll, pitch, yaw]`` rotation for sensor.
-        """
-        if agent_name not in self.agents:
-            print("No such agent %s" % agent_name)
-        elif sensor_name not in self.agents[agent_name].sensors:
-            print("No sensor %s on agent" % sensor_name)
-        else:
-            command_to_send = RotateSensorCommand(agent_name, sensor_name, rotation)
-            self._enqueue_command(command_to_send)
-
     def draw_line(self, start, end, color=None, thickness=10.0):
         """Draws a debug line in the world
 

--- a/src/holodeck/sensors.py
+++ b/src/holodeck/sensors.py
@@ -4,7 +4,7 @@ import json
 import numpy as np
 import holodeck
 
-from holodeck.command import SetSensorEnabledCommand
+from holodeck.command import SetSensorEnabledCommand, RGBCameraRateCommand, RotateSensorCommand
 from holodeck.exceptions import HolodeckConfigurationException
 
 
@@ -70,6 +70,20 @@ class HolodeckSensor:
             :obj:`tuple`: Sensor data shape
         """
         raise NotImplementedError("Child class must implement this property")
+
+    def rotate(self, rotation):
+        """Rotate the sensor. It will be applied in approximately three ticks.
+        :meth:`~holodeck.environments.HolodeckEnvironment.step` or
+        :meth:`~holodeck.environments.HolodeckEnvironment.tick`.)
+
+        This will not persist after a call to reset(). If you want a persistent rotation for a sensor,
+        specify it in your scenario configuration.
+
+        Args:
+            rotation (:obj:`list` of :obj:`float`): rotation for sensor (see :ref:`rotations`).
+        """
+        command_to_send = RotateSensorCommand(self.agent_name, self.name, rotation)
+        self._client.command_center.enqueue_command(command_to_send)
 
 
 class DistanceTask(HolodeckSensor):
@@ -224,6 +238,21 @@ class RGBCamera(HolodeckSensor):
     def data_shape(self):
         return self.shape
 
+    def set_ticks_per_capture(self, ticks_per_capture):
+        """Sets this RGBCamera to capture a new frame every ticks_per_capture.
+
+        The sensor's image will remain unchanged between captures.
+
+        This method must be called after every call to env.reset.
+
+        Args:
+            ticks_per_capture (:obj:`int`): The amount of ticks to wait between camera captures.
+        """
+        if not isinstance(ticks_per_capture, int) or ticks_per_capture < 1:
+            raise HolodeckConfigurationException("Invalid ticks_per_capture value " + str(ticks_per_capture))
+
+        command_to_send = RGBCameraRateCommand(self.agent_name, self.name, ticks_per_capture)
+        self._client.command_center.enqueue_command(command_to_send)
 
 class OrientationSensor(HolodeckSensor):
     """Gets the forward, right, and up vector for the agent.

--- a/tests/sensors/conftest.py
+++ b/tests/sensors/conftest.py
@@ -14,9 +14,12 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('ticks_per_capture', [30, 15, 10, 5, 2])
     elif 'joint_agent_type' in metafunc.fixturenames:
         metafunc.parametrize('joint_agent_type', [("AndroidAgent", android_joints), ("HandAgent", handagent_joints)])
+    elif 'rotation_env' in metafunc.fixturenames:
+        metafunc.parametrize('rotation_env', ['rotation_env'], indirect=True)
 
 
-shared_env = None
+shared_1024_env = None
+
 
 @pytest.fixture
 def env_1024(request):
@@ -47,16 +50,58 @@ def env_1024(request):
         "window_height": 1024
     }
     
-    global shared_env
+    global shared_1024_env
 
-    if shared_env is None:
+    if shared_1024_env is None:
         binary_path = holodeck.packagemanager.get_binary_path_for_package("DefaultWorlds")
-        shared_env = holodeck.environments.HolodeckEnvironment(scenario=cfg,
-                                                               binary_path=binary_path,
-                                                               show_viewport=False,
-                                                               uuid=str(uuid.uuid4()))
+        shared_1024_env = holodeck.environments.HolodeckEnvironment(scenario=cfg,
+                                                                    binary_path=binary_path,
+                                                                    show_viewport=False,
+                                                                    uuid=str(uuid.uuid4()))
 
-    return shared_env
+    shared_1024_env.reset()
+
+    return shared_1024_env
+
+
+shared_rotation_env = None
+
+
+@pytest.fixture
+def rotation_env(request):
+    """Shares the RotationSensor configuration
+    """
+    cfg = {
+        "name": "test_rotation_sensor",
+        "world": "TestWorld",
+        "main_agent": "sphere0",
+        "agents": [
+            {
+                "agent_name": "sphere0",
+                "agent_type": "SphereAgent",
+                "sensors": [
+                    {
+                        "sensor_type": "RGBCamera",
+                        "rotation": [0, -90, 0]
+                    }
+                ],
+                "control_scheme": 0,
+                "location": [.95, -1.75, .5]
+            }
+        ]
+    }
+
+    global shared_rotation_env
+
+    if shared_rotation_env is None:
+        binary_path = holodeck.packagemanager.get_binary_path_for_package("DefaultWorlds")
+        shared_rotation_env = holodeck.environments.HolodeckEnvironment(scenario=cfg,
+                                                                        binary_path=binary_path,
+                                                                        show_viewport=False,
+                                                                        uuid=str(uuid.uuid4()))
+
+    shared_rotation_env.reset()
+    return shared_rotation_env
 
 
 android_joints = [
@@ -155,6 +200,7 @@ android_joints = [
     "ring_03_r_swing1",
     "pinky_03_r_swing1"
 ]
+
 
 handagent_joints = [
     "hand_r_swing1",

--- a/tests/sensors/test_sensor_rotation.py
+++ b/tests/sensors/test_sensor_rotation.py
@@ -1,0 +1,36 @@
+import cv2, os
+from tests.utils.equality import mean_square_err
+
+
+def test_sensor_rotation(rotation_env, request):
+    """Validates that calling rotate actually rotates the sensor using the RGBCamera.
+
+    Positions the SphereAgent above the target cube so that if it rotates down, it will capture the test
+    pattern.
+    """
+    # Re-use the screenshot for test_rgb_camera
+    rotation_env.agents["sphere0"].sensors["RGBCamera"].rotate([0, 0, 0])
+    pixels = rotation_env.tick(10)["RGBCamera"][:, :, 0:3]
+
+    baseline = cv2.imread(os.path.join(request.fspath.dirname, "expected", "256.png"))
+
+    err = mean_square_err(pixels, baseline)
+    assert err < 2000, \
+        "The sensor appeared to not rotate!"
+
+
+def test_sensor_rotation_resets_after_reset(rotation_env):
+    """Validates that the sensor rotation is reset back to the starting position after calling ``.reset()``.
+    """
+
+    # Re-use the screenshot for test_rgb_camera
+    rotation_env.agents["sphere0"].sensors["RGBCamera"].rotate([0, 0, 0])
+    pixels_before = rotation_env.tick(5)["RGBCamera"][:, :, 0:3]
+
+    rotation_env.reset()
+
+    pixels_after = rotation_env.tick(5)["RGBCamera"][:, :, 0:3]
+
+    err = mean_square_err(pixels_before, pixels_after)
+    assert err > 2000, \
+        "The images were too similar! Did the sensor not rotate back?"

--- a/tests/utils/captures.py
+++ b/tests/utils/captures.py
@@ -1,0 +1,16 @@
+import cv2
+
+
+def display(pixels, title="Camera Output"):
+    """Displays the given capture in a CV2 window. Useful for debugging
+
+    Args:
+        pixels: MxNx3 array of pixels
+        title: The title of the window
+
+    """
+    cv2.namedWindow(title)
+    cv2.moveWindow(title, 500, 500)
+    cv2.imshow(title, pixels[:, :, 0:3])
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()


### PR DESCRIPTION
- Move set_ticks_per_capture to the `RGBCamera` class
- Fix `RGBCameraRateCommand` to allow sensor name to be specified
- Remove ticks per capture methods from `HolodeckEnvironment` / `HolodeckAgent`
- Update `test_ticks_per_capture` to use a different camera name to test for regression
- Add tests for sensor rotation
- Move sensor rotation code to the `HolodeckSensor`
- Update changelog