### PR TITLE
Fix/scenario config fixes #351

### DIFF
--- a/docs/usage/examples/custom-scenarios.rst
+++ b/docs/usage/examples/custom-scenarios.rst
@@ -32,6 +32,7 @@ Example
    cfg = {
        "name": "test_rgb_camera",
        "world": "ExampleWorld",
+       "package_name": "DefaultWorlds",
        "main_agent": "sphere0",
        "agents": [
            {

--- a/src/holodeck/__init__.py
+++ b/src/holodeck/__init__.py
@@ -5,4 +5,4 @@ __version__ = '0.3.1dev'
 from holodeck.holodeck import make
 from holodeck.packagemanager import *
 
-__all__ = ['agents', 'environments', 'exceptions', 'holodeck', 'packagemanager', 'sensors']
+__all__ = ['agents', 'environments', 'exceptions', 'holodeck', 'make', 'packagemanager', 'sensors']

--- a/src/holodeck/holodeck.py
+++ b/src/holodeck/holodeck.py
@@ -2,7 +2,10 @@
 import uuid
 
 from holodeck.environments import HolodeckEnvironment
-from holodeck.packagemanager import get_scenario, get_binary_path_for_scenario, get_package_config_for_scenario
+from holodeck.packagemanager import get_scenario,\
+    get_binary_path_for_scenario,\
+    get_package_config_for_scenario,\
+    get_binary_path_for_package
 from holodeck.exceptions import HolodeckException
 
 
@@ -55,15 +58,16 @@ def make(scenario_name="", scenario_cfg=None, gl_version=GL_VERSION.OPENGL4, win
     """
 
     param_dict = dict()
+    binary_path = None
+
     if scenario_name != "":
         scenario = get_scenario(scenario_name)
+        binary_path = get_binary_path_for_scenario(scenario_name)
     elif scenario_cfg is not None:
         scenario = scenario_cfg
-        scenario_name = "{}-{}".format(scenario["name"], scenario["world"])
+        binary_path = get_binary_path_for_package(scenario["package_name"])
     else:
         raise HolodeckException("You must specify scenario_name or scenario_config")
-
-    binary_path = get_binary_path_for_scenario(scenario_name)
 
     # Get pre-start steps
     package_config = get_package_config_for_scenario(scenario)

--- a/tests/agents/test_randomization.py
+++ b/tests/agents/test_randomization.py
@@ -8,6 +8,7 @@ from holodeck.environments import HolodeckEnvironment
 base_conf = {
     "name": "test_randomization",
     "world": "TestWorld",
+    "package_name": "DefaultWorlds",
     "main_agent": "sphere0",
     "agents": [
         {

--- a/tests/scenarios/test_using_make.py
+++ b/tests/scenarios/test_using_make.py
@@ -29,6 +29,9 @@ base_conf = {
 
 def test_using_make_to_create_worlds():
 
+    # TODO: We need some way of communicating with the engine to verify that the expected level was loaded.
+    # If the level isn't found, then Unreal just picks a default one, so we're missing that case
+
     with make(scenario_cfg=base_conf) as env:
         for _ in range(0, 10):
             env.tick()

--- a/tests/scenarios/test_using_make.py
+++ b/tests/scenarios/test_using_make.py
@@ -1,0 +1,53 @@
+from holodeck import make
+
+base_conf = {
+    "name": "test_randomization",
+    "world": "TestWorld",
+    "package_name": "DefaultWorlds",
+    "main_agent": "sphere0",
+    "agents": [
+        {
+            "agent_name": "sphere0",
+            "agent_type": "SphereAgent",
+            "sensors": [
+                {
+                    "sensor_type": "LocationSensor"
+                },
+                {
+                    "sensor_type": "RotationSensor"
+                }
+            ],
+            "control_scheme": 0,
+            "location": [0.95, -1.75, 0.5],
+            "rotation": [1.0, 2.0, 3.0],
+            "location_randomization": [0.6, 0.5, 0.5],
+            "rotation_randomization": [0.4, 0.3, 0.6]
+        }
+    ]
+}
+
+
+def test_using_make_to_create_worlds():
+
+    with make(scenario_cfg=base_conf) as env:
+        for _ in range(0, 10):
+            env.tick()
+
+    conf = base_conf
+    conf["world"] = "CyberPunkCity"
+    with make(scenario_cfg=conf) as env:
+        for _ in range(0, 10):
+            env.tick()
+
+    conf["world"] = "EuropeanForest"
+    with make(scenario_cfg=conf) as env:
+        for _ in range(0, 10):
+            env.tick()
+
+    conf["world"] = "InfiniteForest"
+    with make(scenario_cfg=conf) as env:
+        for _ in range(0, 10):
+            env.tick()
+
+
+


### PR DESCRIPTION
Fixed the bug where passing a config map object to holodeck.make wasn't working as expected. Updated the documentation. This resolves #351 