### PR TITLE
Add test dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM nvidia/cudagl:9.2-runtime-ubuntu18.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-dev ipython3 module-init-tools curl build-essential python3-pip
 
+# OpenCV's runtime dependencies
+RUN apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6
+
 RUN pip3 install -U pip setuptools wheel
 
 RUN pip3 install numpy posix_ipc holodeck pytest opencv-python


### PR DESCRIPTION
Add test dependencies for open-cv for tests that depend on open-cv to run. We were previously getting an error about a missing dependency. Closes #347 