### PR TITLE
Make Dexterity test `skipif` statements work

### DIFF
--- a/tests/sensors/test_ball_location_and_reward.py
+++ b/tests/sensors/test_ball_location_and_reward.py
@@ -33,7 +33,7 @@ cfg = {
     }
 
 
-@pytest.mark.skip("Dexterity" not in holodeck.installed_packages(),
+@pytest.mark.skipif("Dexterity" not in holodeck.installed_packages(),
                     reason='Dexterity package not installed')
 def test_ball_location_and_reward():
     """Shuffle the ball using a seed. Ensure that after shuffling the ball location sensor

--- a/tests/sensors/test_ball_location_and_reward.py
+++ b/tests/sensors/test_ball_location_and_reward.py
@@ -33,7 +33,7 @@ cfg = {
     }
 
 
-pytest.mark.skipif("Dexterity" not in holodeck.installed_packages(),
+@pytest.mark.skip("Dexterity" not in holodeck.installed_packages(),
                     reason='Dexterity package not installed')
 def test_ball_location_and_reward():
     """Shuffle the ball using a seed. Ensure that after shuffling the ball location sensor

--- a/tests/sensors/test_clean_up_reward.py
+++ b/tests/sensors/test_clean_up_reward.py
@@ -29,7 +29,7 @@ cfg = {
     }
 
 
-pytest.mark.skipif("Dexterity" not in holodeck.installed_packages(),
+@pytest.mark.skipif("Dexterity" not in holodeck.installed_packages(),
                     reason='Dexterity package not installed')
 def test_ball_location_and_reward():
     """This is currently a stub test. There is no way to reliably test the trash world so this is just meant to a manual


### PR DESCRIPTION
Adds two characters that make all the difference. Closes #404.