### PR TITLE
Fix the max open files error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ worlds/
 build/
 env/
 venv/
+.venv
 docs/_build
 dist/
 holodeck.egg-info/

--- a/src/holodeck/agents.py
+++ b/src/holodeck/agents.py
@@ -93,6 +93,23 @@ class HolodeckAgent:
         self._current_control_scheme = 0
         self.set_control_scheme(0)
 
+    def clean_up_resources(self):
+        if hasattr(self, "_action_buffer"):
+            del self._action_buffer
+        if hasattr(self, "_teleport_type_buffer"):
+            del self._teleport_type_buffer
+        if hasattr(self, "_teleport_buffer"):
+            del self._teleport_buffer
+        if hasattr(self, "_control_scheme_buffer"):
+            del self._control_scheme_buffer
+
+        for key in list(self.agent_state_dict.keys()):
+            del self.agent_state_dict[key]
+
+        for key in list(self.sensors.keys()):
+            self.sensors[key].clean_up_resources()
+            del self.sensors[key]
+
     def act(self, action):
         """Sets the command for the agent. Action depends on the agent type and current control
         scheme.

--- a/src/holodeck/command.py
+++ b/src/holodeck/command.py
@@ -133,6 +133,12 @@ class CommandCenter:
         self._commands = CommandsGroup()
         self._should_write_to_command_buffer = False
 
+    def clean_up_resources(self):
+        if hasattr(self, "_command_bool_ptr"):
+            del self._command_bool_ptr
+        if hasattr(self, "_command_buffer_ptr"):
+            del self._command_buffer_ptr
+
     def clear(self):
         """Clears pending commands
 

--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -6,7 +6,6 @@ It specifies an environment, which contains a number of agents, and the interfac
 with the agents.
 """
 import atexit
-import gc
 import os
 import random
 import subprocess
@@ -663,8 +662,6 @@ class HolodeckEnvironment:
             return
 
         self.clean_up_resources()
-        # TODO(daniekpo) remove this
-        gc.collect()
 
         if hasattr(self, "_client"):
             self._client.unlink()

--- a/src/holodeck/holodeckclient.py
+++ b/src/holodeck/holodeckclient.py
@@ -25,7 +25,7 @@ class HolodeckClient:
         self.should_timeout = should_timeout
 
         self._memory = dict()
-        self._sensors = dict()
+        self._sensors = dict()  # never used
         self._agents = dict()
         self._settings = dict()
 
@@ -81,10 +81,13 @@ class HolodeckClient:
             sem.release()
 
         def posix_unlink():
+            self._semaphore1.close()
+            self._semaphore2.close()
             posix_ipc.unlink_semaphore(self._semaphore1.name)
             posix_ipc.unlink_semaphore(self._semaphore2.name)
-            for shmem_block in self._memory.values():
-                shmem_block.unlink()
+            for key in list(self._memory.keys()):
+                self._memory[key].unlink()
+                del self._memory[key]
 
         self._get_semaphore_fn = posix_acquire_semaphore
         self._release_semaphore_fn = posix_release_semaphore

--- a/src/holodeck/sensors.py
+++ b/src/holodeck/sensors.py
@@ -35,6 +35,10 @@ class HolodeckSensor:
 
         self.config = {} if config is None else config
 
+    def clean_up_resources(self):
+        if hasattr(self, "_sensor_data_buffer"):
+            del self._sensor_data_buffer
+
     @property
     def sensor_data(self):
         """Get the sensor data buffer

--- a/src/holodeck/shmem.py
+++ b/src/holodeck/shmem.py
@@ -40,14 +40,11 @@ class Shmem:
         elif os.name == "posix":
             self._mem_path = "/dev/shm/HOLODECK_MEM" + uuid + "_" + name
             f = os.open(self._mem_path, os.O_CREAT | os.O_TRUNC | os.O_RDWR)
-            self._mem_file = f
             os.ftruncate(f, size_bytes)
             os.fsync(f)
 
-            # TODO - I think we are leaking a file object here. Unfortunately, we
-            #        can't just .close() it since numpy acquires a reference to it
-            #        below and I can't find a way to release it in __linux_unlink__()
             self._mem_pointer = mmap.mmap(f, size_bytes)
+            os.close(f)  # we don't need the file descriptor to stay open. see the man page
         else:
             raise HolodeckException("Currently unsupported os: " + os.name)
 
@@ -64,7 +61,7 @@ class Shmem:
             raise HolodeckException("Currently unsupported os: " + os.name)
 
     def __linux_unlink__(self):
-        os.close(self._mem_file)
+        del self.np_array
         os.remove(self._mem_path)
 
     def __windows_unlink__(self):


### PR DESCRIPTION
closes #356
closes #407

It turns out that calling os.remove or unlinking a mapped memory file might delete the actual file but the OS keeps the mapped file open until there's no reference to that memory block. We were removing the mapped memory files we created, but since we still kept references to the location in memory, the OS left the file (handle) open. Running multiple Holodeck instances eventually in one process eventually exhausts the open file limit.

----
To verify that this fixed the problem, you can run the script below:
First set the open files soft limit to 40 or some small number
`ulimit -Sn 40`

```
import holodeck
import os

def run_script():
    print("Process ID: {}".format(os.getpid()))
    input("press Enter to continue")
    with holodeck.make("MazeWorld-FinishMazeSphere") as env:
        pass

    input("press Enter to continue")
    with holodeck.make("MazeWorld-FinishMazeSphere") as env:
        pass

    input("press Enter to continue")
    with holodeck.make("MazeWorld-FinishMazeSphere") as env:
        pass

    input("press Enter to continue")
    with holodeck.make("MazeWorld-FinishMazeSphere") as env:
        pass
    
    input("Press Enter to continue")
    with holodeck.make("MazeWorld-FinishMazeSphere") as env:
        pass
```
At each stop use `lsof -p $PID$ | wc -l` to check how many files are open by the python process. It should be a consistent number at each step showing that each `HolodeckEnvironment` instance closed all its open files. When I ran it I got 59. That's just the files/modules that python loads. Without the fix, the script above will fail because the process would have too many open files.