### PR TITLE
Formatting changes from feature/test-cleanup (take 2)

### DIFF
--- a/src/holodeck/environments.py
+++ b/src/holodeck/environments.py
@@ -668,7 +668,7 @@ class HolodeckEnvironment:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        # TODO: Surpress exceptions?
+        # TODO: Suppress exceptions?
         self.__on_exit__()
 
     def _get_single_state(self):

--- a/src/holodeck/holodeckclient.py
+++ b/src/holodeck/holodeckclient.py
@@ -4,6 +4,7 @@ import os
 from holodeck.exceptions import HolodeckException
 from holodeck.shmem import Shmem
 
+
 class HolodeckClient:
     """HolodeckClient for controlling a shared memory session.
 

--- a/tests/agents/handagent/conftest.py
+++ b/tests/agents/handagent/conftest.py
@@ -11,21 +11,17 @@ base_handagent_config = {
         {
             "agent_name": "hand0",
             "agent_type": "HandAgent",
-            "sensors": [
-                {
-                    "sensor_type": "LocationSensor",
-                }
-            ],
+            "sensors": [{"sensor_type": "LocationSensor",}],
             "control_scheme": 2,
-            "location": [0, 0, 1]
+            "location": [0, 0, 1],
         }
-    ]
+    ],
 }
 
 
 def pytest_generate_tests(metafunc):
-    if 'env' in metafunc.fixturenames:
-        metafunc.parametrize('env', [base_handagent_config], indirect=True)
+    if "env" in metafunc.fixturenames:
+        metafunc.parametrize("env", [base_handagent_config], indirect=True)
 
 
 shared_env = -1

--- a/tests/sensors/conftest.py
+++ b/tests/sensors/conftest.py
@@ -3,23 +3,29 @@ import pytest
 import uuid
 import holodeck
 
+
 def pytest_generate_tests(metafunc):
     """Iterate over every scenario
     """
-    if 'resolution' in metafunc.fixturenames:
-        metafunc.parametrize('resolution', [256, 512, 1024, 2048])
-    elif '1024_env' in metafunc.fixturenames:
-        metafunc.parametrize('env_1024', [1024], indirect=True)
-    elif 'ticks_per_capture' in metafunc.fixturenames:
-        metafunc.parametrize('ticks_per_capture', [30, 15, 10, 5, 2])
-    elif 'joint_agent_type' in metafunc.fixturenames:
-        metafunc.parametrize('joint_agent_type', [("AndroidAgent", android_joints), ("HandAgent", handagent_joints)])
-    elif 'abuse_world' in metafunc.fixturenames:
-        metafunc.parametrize('abuse_world', ["abuse_world"], indirect=True)
-    elif 'rotation_env' in metafunc.fixturenames:
-        metafunc.parametrize('rotation_env', ['rotation_env'], indirect=True)
-    elif 'agent_abuse_world' in metafunc.fixturenames:
-        metafunc.parametrize('agent_abuse_world', ['turtle0', 'uav0', 'android0'], indirect=True)
+    if "resolution" in metafunc.fixturenames:
+        metafunc.parametrize("resolution", [256, 512, 1024, 2048])
+    elif "1024_env" in metafunc.fixturenames:
+        metafunc.parametrize("env_1024", [1024], indirect=True)
+    elif "ticks_per_capture" in metafunc.fixturenames:
+        metafunc.parametrize("ticks_per_capture", [30, 15, 10, 5, 2])
+    elif "joint_agent_type" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "joint_agent_type",
+            [("AndroidAgent", android_joints), ("HandAgent", handagent_joints)],
+        )
+    elif "abuse_world" in metafunc.fixturenames:
+        metafunc.parametrize("abuse_world", ["abuse_world"], indirect=True)
+    elif "rotation_env" in metafunc.fixturenames:
+        metafunc.parametrize("rotation_env", ["rotation_env"], indirect=True)
+    elif "agent_abuse_world" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "agent_abuse_world", ["turtle0", "uav0", "android0"], indirect=True
+        )
 
 
 shared_1024_env = None
@@ -40,31 +46,31 @@ def env_1024(request):
                 "sensors": [
                     {
                         "sensor_type": "ViewportCapture",
-                        "configuration": {
-                            "CaptureWidth": 1024,
-                            "CaptureHeight": 1024
-                        }
+                        "configuration": {"CaptureWidth": 1024, "CaptureHeight": 1024},
                     }
                 ],
                 "control_scheme": 0,
-                "location": [.95, -1.75, .5]
+                "location": [0.95, -1.75, 0.5],
             }
         ],
         "window_width": 1024,
-        "window_height": 1024
+        "window_height": 1024,
     }
-    
+
     global shared_1024_env
 
     if shared_1024_env is None:
-        binary_path = holodeck.packagemanager.get_binary_path_for_package("DefaultWorlds")
-        shared_1024_env = holodeck.environments.HolodeckEnvironment(scenario=cfg,
-                                                                    binary_path=binary_path,
-                                                                    show_viewport=False,
-                                                                    uuid=str(uuid.uuid4()))
+        binary_path = holodeck.packagemanager.get_binary_path_for_package(
+            "DefaultWorlds"
+        )
+        shared_1024_env = holodeck.environments.HolodeckEnvironment(
+            scenario=cfg,
+            binary_path=binary_path,
+            show_viewport=False,
+            uuid=str(uuid.uuid4()),
+        )
 
     shared_1024_env.reset()
-
     return shared_1024_env
 
 
@@ -79,19 +85,22 @@ def get_abuse_world():
             scenario=abuse_config,
             binary_path=binary_path,
             show_viewport=False,
-            uuid=str(uuid.uuid4())
+            uuid=str(uuid.uuid4()),
         )
     shared_abuse_env.reset()
     return shared_abuse_env
+
 
 @pytest.fixture
 def abuse_world(request):
     return get_abuse_world()
 
+
 @pytest.fixture
 def agent_abuse_world(request):
     env = get_abuse_world()
     return request.param, env
+
 
 @pytest.fixture
 def rotation_env(request):
@@ -105,29 +114,29 @@ def rotation_env(request):
             {
                 "agent_name": "sphere0",
                 "agent_type": "SphereAgent",
-                "sensors": [
-                    {
-                        "sensor_type": "RGBCamera",
-                        "rotation": [0, -90, 0]
-                    }
-                ],
+                "sensors": [{"sensor_type": "RGBCamera", "rotation": [0, -90, 0]}],
                 "control_scheme": 0,
-                "location": [.95, -1.75, .5]
+                "location": [0.95, -1.75, 0.5],
             }
-        ]
+        ],
     }
 
     global shared_rotation_env
 
     if shared_rotation_env is None:
-        binary_path = holodeck.packagemanager.get_binary_path_for_package("DefaultWorlds")
-        shared_rotation_env = holodeck.environments.HolodeckEnvironment(scenario=cfg,
-                                                                        binary_path=binary_path,
-                                                                        show_viewport=False,
-                                                                        uuid=str(uuid.uuid4()))
+        binary_path = holodeck.packagemanager.get_binary_path_for_package(
+            "DefaultWorlds"
+        )
+        shared_rotation_env = holodeck.environments.HolodeckEnvironment(
+            scenario=cfg,
+            binary_path=binary_path,
+            show_viewport=False,
+            uuid=str(uuid.uuid4()),
+        )
 
     shared_rotation_env.reset()
     return shared_rotation_env
+
 
 abuse_config = {
     "name": "test_abuse_sensor",
@@ -137,40 +146,28 @@ abuse_config = {
         {
             "agent_name": "uav0",
             "agent_type": "UavAgent",
-            "sensors": [
-                {
-                    "sensor_type": "AbuseSensor",
-                }
-            ],
+            "sensors": [{"sensor_type": "AbuseSensor",}],
             "control_scheme": 0,
             "location": [1.5, 0, 9],
-            "rotation": [0, 0, 0]
+            "rotation": [0, 0, 0],
         },
         {
             "agent_name": "android0",
             "agent_type": "AndroidAgent",
-            "sensors": [
-                {
-                    "sensor_type": "AbuseSensor",
-                }
-            ],
+            "sensors": [{"sensor_type": "AbuseSensor",}],
             "control_scheme": 0,
             "location": [0, 0, 10],
-            "rotation": [0, 0, 0]
+            "rotation": [0, 0, 0],
         },
         {
             "agent_name": "turtle0",
             "agent_type": "TurtleAgent",
-            "sensors": [
-                {
-                    "sensor_type": "AbuseSensor",
-                }
-            ],
+            "sensors": [{"sensor_type": "AbuseSensor",}],
             "control_scheme": 0,
             "location": [2, 1.5, 8],
-            "rotation": [0, 0, 0]
-        }
-    ]
+            "rotation": [0, 0, 0],
+        },
+    ],
 }
 
 android_joints = [
@@ -267,7 +264,7 @@ android_joints = [
     "index_03_r_swing1",
     "middle_03_r_swing1",
     "ring_03_r_swing1",
-    "pinky_03_r_swing1"
+    "pinky_03_r_swing1",
 ]
 
 
@@ -294,5 +291,5 @@ handagent_joints = [
     "index_03_r_swing1",
     "middle_03_r_swing1",
     "ring_03_r_swing1",
-    "pinky_03_r_swing1"
+    "pinky_03_r_swing1",
 ]

--- a/tests/sensors/test_rgb_camera.py
+++ b/tests/sensors/test_rgb_camera.py
@@ -3,7 +3,6 @@ import cv2
 import copy
 import os
 import uuid
-
 import pytest
 
 from tests.utils.equality import mean_square_err

--- a/tests/sensors/test_rgb_camera.py
+++ b/tests/sensors/test_rgb_camera.py
@@ -1,7 +1,6 @@
 import holodeck
 import cv2
 import copy
-import numpy as np
 import os
 import uuid
 

--- a/tests/sensors/test_rgb_camera.py
+++ b/tests/sensors/test_rgb_camera.py
@@ -5,6 +5,8 @@ import numpy as np
 import os
 import uuid
 
+import pytest
+
 from tests.utils.equality import mean_square_err
 
 

--- a/tests/worlds/mazeworld/test_weather_programmatic.py
+++ b/tests/worlds/mazeworld/test_weather_programmatic.py
@@ -146,9 +146,7 @@ def test_weather_fog_density_programmatic(
     assert err < max_err
 
 
-def test_fail_incorrect_weather_type_programmatic(
-    weather_env: HolodeckEnvironment,
-):
+def test_fail_incorrect_weather_type_programmatic(weather_env: HolodeckEnvironment):
     """
     Validate that an exception is thrown when an invalid weather type is
     specified programmatically
@@ -181,8 +179,8 @@ def weather_env(request: FixtureRequest):
 
     cur_programmatic_test_name = request.function.__name__
     if (
-            cur_programmatic_test_name != last_programmatic_test_name
-            or cur_programmatic_weather_env is None
+        cur_programmatic_test_name != last_programmatic_test_name
+        or cur_programmatic_weather_env is None
     ):
         cur_programmatic_weather_env = env_with_config(weather_config)
 

--- a/tests/worlds/mazeworld/test_weather_programmatic.py
+++ b/tests/worlds/mazeworld/test_weather_programmatic.py
@@ -4,17 +4,22 @@ from holodeck import HolodeckException
 from holodeck.environments import HolodeckEnvironment
 
 from tests.utils.captures import compare_rgb_sensor_data_with_baseline
-from tests.worlds.mazeworld.conftest import weather_type_test_data, \
-    time_test_data, day_cycle_test_data, fog_density_test_data, \
-    env_with_config, weather_config
+from tests.worlds.mazeworld.conftest import (
+    weather_type_test_data,
+    time_test_data,
+    day_cycle_test_data,
+    fog_density_test_data,
+    env_with_config,
+    weather_config,
+)
 
 
 @pytest.mark.parametrize("weather_type, max_err", weather_type_test_data)
 def test_weather_type_programmatic(
-        weather_type: str,
-        max_err: float,
-        weather_env: HolodeckEnvironment,
-        request: FixtureRequest,
+    weather_type: str,
+    max_err: float,
+    weather_env: HolodeckEnvironment,
+    request: FixtureRequest,
 ) -> None:
     """Validate that weather type can be set programmatically by comparing
     RGB sensor data with saved baseline data
@@ -39,10 +44,10 @@ def test_weather_type_programmatic(
 
 @pytest.mark.parametrize("hour, max_err", time_test_data)
 def test_weather_time_programmatic(
-        hour: float,
-        max_err: float,
-        weather_env: HolodeckEnvironment,
-        request: FixtureRequest,
+    hour: float,
+    max_err: float,
+    weather_env: HolodeckEnvironment,
+    request: FixtureRequest,
 ) -> None:
     """Validate that time can be set programmatically by comparing RGB
     sensor data with saved baseline data
@@ -70,12 +75,12 @@ def test_weather_time_programmatic(
     "cycle_length, ticks, max_err_before, max_err_after", day_cycle_test_data
 )
 def test_weather_day_cycle_programmatic(
-        cycle_length: float,
-        ticks: int,
-        max_err_before: float,
-        max_err_after: float,
-        weather_env: HolodeckEnvironment,
-        request: FixtureRequest,
+    cycle_length: float,
+    ticks: int,
+    max_err_before: float,
+    max_err_after: float,
+    weather_env: HolodeckEnvironment,
+    request: FixtureRequest,
 ) -> None:
     """Verify that day cycle can be started programmatically by comparing RGB
     sensor data with saved baseline data
@@ -114,10 +119,10 @@ def test_weather_day_cycle_programmatic(
 
 @pytest.mark.parametrize("fog_density, max_err", fog_density_test_data)
 def test_weather_fog_density_programmatic(
-        fog_density: float,
-        max_err: float,
-        weather_env: HolodeckEnvironment,
-        request: FixtureRequest,
+    fog_density: float,
+    max_err: float,
+    weather_env: HolodeckEnvironment,
+    request: FixtureRequest,
 ) -> None:
     """Validate that fog density can be set programmatically by comparing RGB
     sensor data with saved baseline data
@@ -141,7 +146,9 @@ def test_weather_fog_density_programmatic(
     assert err < max_err
 
 
-def test_fail_incorrect_weather_type_programmatic(weather_env: HolodeckEnvironment,):
+def test_fail_incorrect_weather_type_programmatic(
+    weather_env: HolodeckEnvironment,
+):
     """
     Validate that an exception is thrown when an invalid weather type is
     specified programmatically


### PR DESCRIPTION
Various Black formatting changes. [Black takes a philosophical stance against range formatting](https://github.com/psf/black/issues/134#issuecomment-381726788), so formatting just my section of code is harder.

The diff on `feature/test-cleanup` was cluttered with unrelated formatting changes that  were mixed in with other commits. For reference, my painful, roundabout process for "moving" those changes out wholesale was:
1. Start with a clean working directory 
1. `git diff origin/develop HEAD > changes.patch` to get a patch file of all changes made since
1. `git apply -R changes.patch`, where `-R` applies the patch file as a "reset" (or "reverse"), to create a set of unstaged changes that would negate the diff of the PR if committed. This commit wouldn't actually "undo" the changes because history is preserved, but the result is the same. If we use the equality `1 + 2 + 3 + -6 = 0` as an analogy, these changes are the 6.
1. `git add --patch` to selectively stage formatting _removal_ changes
1. `git diff --staged -R > formatting.patch` to get an inverted patch file that _adds_ formatting changes. `git diff --staged` shows us all of the formatting changes we staged to _remove_, so `git diff --staged -R` reverses that.
1. Commit the staged formatting removal changes
1. `git checkout HEAD .` to get rid of remaining unstaged changes on `feature/test-cleanup`
1. `git checkout -b test-cleanup-formatting` to create a new branch off of `feature/test-cleanup`
1. `git apply formatting.patch` to apply formatting changes + stage + commit

If you see something that could have been done more simply (besides making more specific commits in the first place), let me know in a comment.